### PR TITLE
fix[swapPage]: fixed mobile right side whitespace

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -40,7 +40,7 @@ const BodyWrapper = styled.div`
   align-items: center;
   flex: 1;
   // overflow-y: auto;
-  // overflow-x: hidden;
+  overflow-x: hidden;
   z-index: 1;
   justify-content: center;
   background-repeat: no-repeat;


### PR DESCRIPTION
Slight tweak to fix some whitespace on the right side of the swap page when on mobile.

Was due to the right side of the logo images (the donkeys in the background) forcing that right side further than the background. Just tweaked an overflow property to fix it.

The property does affect other pages (as it's a property of a container); but I checked other pages both in and not in mobile view and all seems to be fine.